### PR TITLE
feat: 倒计时页面响应式分栏布局升级

### DIFF
--- a/src/main/java/com/zen/timer/view/CountdownView.java
+++ b/src/main/java/com/zen/timer/view/CountdownView.java
@@ -8,21 +8,26 @@ import javafx.beans.binding.Bindings;
 import javafx.collections.ListChangeListener;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ProgressBar;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Spinner;
 import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
-import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.shape.Circle;
+
+import java.util.List;
 
 /**
  * 现代化的倒计时界面，包含主题切换、预设选择、进度条等新特性。
@@ -41,9 +46,19 @@ public class CountdownView {
         BorderPane root = new BorderPane();
         root.getStyleClass().add("app-root");
 
-        VBox center = new VBox(24);
-        center.setAlignment(Pos.CENTER);
-        center.setPadding(new Insets(32));
+        ScrollPane scrollPane = new ScrollPane();
+        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        scrollPane.setFitToWidth(true);
+        scrollPane.getStyleClass().add("app-scroll");
+        root.setCenter(scrollPane);
+
+        VBox content = new VBox(32);
+        content.setAlignment(Pos.TOP_CENTER);
+        content.setPadding(new Insets(48, 48, 64, 48));
+        content.setFillWidth(true);
+        scrollPane.setContent(content);
+        scrollPane.viewportBoundsProperty().addListener((obs, oldBounds, newBounds) ->
+                content.setPrefWidth(newBounds.getWidth()));
 
         Label title = new Label("Nebula 倒计时中心");
         title.getStyleClass().add("app-title");
@@ -53,6 +68,22 @@ public class CountdownView {
 
         VBox header = new VBox(8, title, subtitle);
         header.setAlignment(Pos.CENTER);
+
+        ToggleButton themeToggle = new ToggleButton();
+        themeToggle.getStyleClass().add("theme-toggle");
+        themeToggle.selectedProperty().bindBidirectional(themeManager.darkModeProperty());
+        themeToggle.textProperty().bind(Bindings.when(themeManager.darkModeProperty())
+                .then("夜间模式")
+                .otherwise("日间模式"));
+        themeToggle.setTooltip(new Tooltip("切换整体视觉主题"));
+
+        BorderPane hero = new BorderPane();
+        hero.setCenter(header);
+        hero.setRight(themeToggle);
+        hero.setMaxWidth(1200);
+        BorderPane.setAlignment(themeToggle, Pos.TOP_RIGHT);
+        content.getChildren().add(hero);
+        VBox.setMargin(hero, new Insets(0, 0, 16, 0));
 
         Label timeDisplay = new Label();
         timeDisplay.getStyleClass().add("time-display");
@@ -70,6 +101,7 @@ public class CountdownView {
         ProgressBar progressBar = new ProgressBar();
         progressBar.getStyleClass().add("countdown-progress");
         progressBar.setPrefWidth(420);
+        progressBar.setMaxWidth(Double.MAX_VALUE);
         progressBar.progressProperty().bind(viewModel.progressProperty());
 
         Label finishLabel = new Label();
@@ -80,10 +112,20 @@ public class CountdownView {
         statusLabel.getStyleClass().add("status-label");
         statusLabel.textProperty().bind(viewModel.statusMessageProperty());
 
-        VBox displayCard = new VBox(16, timeDisplay, progressBar, finishLabel, statusLabel);
-        displayCard.getStyleClass().add("display-card");
+        Circle halo = new Circle(140);
+        halo.getStyleClass().add("halo-circle");
+
+        StackPane timeStack = new StackPane(halo, timeDisplay);
+        timeStack.setAlignment(Pos.CENTER);
+
+        VBox displayCard = new VBox(16, timeStack, progressBar, finishLabel, statusLabel);
+        displayCard.getStyleClass().addAll("display-card", "content-card");
         displayCard.setAlignment(Pos.CENTER);
+        displayCard.setFillWidth(true);
         displayCard.setPadding(new Insets(24));
+        displayCard.setMinWidth(280);
+        displayCard.setPrefWidth(360);
+        displayCard.setMaxWidth(Double.MAX_VALUE);
 
         Spinner<Integer> hourSpinner = new Spinner<>();
         hourSpinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 23, 0));
@@ -101,34 +143,58 @@ public class CountdownView {
                 labeledBox("分钟", minuteSpinner),
                 labeledBox("秒钟", secondSpinner));
         timeInputs.getStyleClass().add("time-inputs");
-        timeInputs.setAlignment(Pos.CENTER);
+        timeInputs.setAlignment(Pos.CENTER_LEFT);
 
         FlowPane presetPane = new FlowPane();
         presetPane.setHgap(12);
         presetPane.setVgap(12);
-        presetPane.setAlignment(Pos.CENTER);
+        presetPane.setAlignment(Pos.TOP_LEFT);
         presetPane.getStyleClass().add("preset-pane");
 
         bindPresets(presetPane, hourSpinner, minuteSpinner, secondSpinner);
 
         HBox controlBar = buildControlBar(hourSpinner, minuteSpinner, secondSpinner);
+        controlBar.setMaxWidth(Double.MAX_VALUE);
 
-        ToggleButton themeToggle = new ToggleButton();
-        themeToggle.getStyleClass().add("theme-toggle");
-        themeToggle.selectedProperty().bindBidirectional(themeManager.darkModeProperty());
-        themeToggle.textProperty().bind(Bindings.when(themeManager.darkModeProperty())
-                .then("夜间模式")
-                .otherwise("日间模式"));
-        themeToggle.setTooltip(new Tooltip("切换整体视觉主题"));
+        Label inputTitle = new Label("时间输入与控制");
+        inputTitle.getStyleClass().add("card-title");
 
-        Circle halo = new Circle(140);
-        halo.getStyleClass().add("halo-circle");
+        Label inputSubtitle = new Label("自定义倒计时，或快速套用精心挑选的番茄节奏");
+        inputSubtitle.getStyleClass().add("card-subtitle");
 
-        Region spacer = new Region();
-        VBox.setVgrow(spacer, Priority.ALWAYS);
+        Label presetLabel = new Label("推荐预设");
+        presetLabel.getStyleClass().add("section-title");
 
-        center.getChildren().addAll(header, halo, displayCard, timeInputs, presetPane, controlBar, themeToggle, spacer);
-        root.setCenter(center);
+        VBox presetSection = new VBox(8, presetLabel, presetPane);
+
+        VBox inputCard = new VBox(20);
+        inputCard.getStyleClass().add("content-card");
+        inputCard.setAlignment(Pos.TOP_LEFT);
+        inputCard.setPadding(new Insets(24));
+        inputCard.setMinWidth(280);
+        inputCard.setPrefWidth(360);
+        inputCard.setMaxWidth(Double.MAX_VALUE);
+        inputCard.getChildren().addAll(inputTitle, inputSubtitle, timeInputs, presetSection, controlBar);
+
+        presetPane.prefWrapLengthProperty().bind(Bindings.max(0, inputCard.widthProperty().subtract(48)));
+
+        VBox roadmapCard = buildRoadmapCard();
+
+        GridPane cardGrid = new GridPane();
+        cardGrid.setHgap(24);
+        cardGrid.setVgap(24);
+        cardGrid.setAlignment(Pos.TOP_CENTER);
+        cardGrid.setMaxWidth(1200);
+
+        List<Node> cards = List.of(displayCard, inputCard, roadmapCard);
+        cards.forEach(card -> {
+            GridPane.setHgrow(card, Priority.ALWAYS);
+            GridPane.setVgrow(card, Priority.NEVER);
+        });
+
+        configureResponsiveLayout(content, cardGrid, cards);
+
+        content.getChildren().add(cardGrid);
 
         Scene scene = new Scene(root, 900, 640);
         scene.getStylesheets().add(getClass().getResource("/com/zen/timer/styles/app-theme.css").toExternalForm());
@@ -182,7 +248,7 @@ public class CountdownView {
                 viewModel.statusProperty()));
 
         HBox controls = new HBox(18, startButton, toggleButton, resetButton);
-        controls.setAlignment(Pos.CENTER);
+        controls.setAlignment(Pos.CENTER_LEFT);
         controls.getStyleClass().add("control-bar");
         return controls;
     }
@@ -228,5 +294,62 @@ public class CountdownView {
         VBox box = new VBox(6, label, spinner);
         box.setAlignment(Pos.CENTER);
         return box;
+    }
+
+    private void configureResponsiveLayout(VBox container, GridPane gridPane, List<Node> cards) {
+        container.widthProperty().addListener((obs, oldWidth, newWidth) ->
+                updateResponsiveGrid(gridPane, cards, newWidth.doubleValue()));
+        double initialWidth = container.getWidth() > 0 ? container.getWidth() : 900;
+        updateResponsiveGrid(gridPane, cards, initialWidth);
+    }
+
+    private void updateResponsiveGrid(GridPane gridPane, List<Node> cards, double width) {
+        if (width <= 0) {
+            return;
+        }
+        int columns = width >= 1280 ? 3 : width >= 900 ? 2 : 1;
+        gridPane.getChildren().setAll(cards);
+        for (int i = 0; i < cards.size(); i++) {
+            Node card = cards.get(i);
+            GridPane.setColumnIndex(card, i % columns);
+            GridPane.setRowIndex(card, i / columns);
+        }
+    }
+
+    private VBox buildRoadmapCard() {
+        Label title = new Label("Nebula Roadmap");
+        title.getStyleClass().add("card-title");
+
+        Label subtitle = new Label("循序渐进迭代，让倒计时体验持续进化");
+        subtitle.getStyleClass().add("card-subtitle");
+
+        VBox roadmapList = new VBox(12,
+                roadmapItem("v1.1 焕新界面", "响应式布局、卡片化信息展示", "进行中", "status-active"),
+                roadmapItem("v1.2 深度专注", "多场景 Preset、跨设备同步", "策划中", "status-planned"),
+                roadmapItem("v1.3 工作流加速", "自动提醒、统计洞察与分享", "展望", "status-future"));
+
+        VBox roadmapCard = new VBox(18, title, subtitle, roadmapList);
+        roadmapCard.getStyleClass().add("content-card");
+        roadmapCard.setAlignment(Pos.TOP_LEFT);
+        roadmapCard.setPadding(new Insets(24));
+        roadmapCard.setMinWidth(280);
+        roadmapCard.setPrefWidth(320);
+        roadmapCard.setMaxWidth(Double.MAX_VALUE);
+        return roadmapCard;
+    }
+
+    private VBox roadmapItem(String milestone, String focus, String status, String statusStyle) {
+        Label milestoneLabel = new Label(milestone);
+        milestoneLabel.getStyleClass().add("roadmap-phase");
+
+        Label focusLabel = new Label(focus);
+        focusLabel.getStyleClass().add("roadmap-focus");
+
+        Label statusLabel = new Label(status);
+        statusLabel.getStyleClass().addAll("roadmap-status", statusStyle);
+
+        VBox item = new VBox(4, milestoneLabel, focusLabel, statusLabel);
+        item.getStyleClass().add("roadmap-item");
+        return item;
     }
 }

--- a/src/main/resources/com/zen/timer/styles/app-theme.css
+++ b/src/main/resources/com/zen/timer/styles/app-theme.css
@@ -7,6 +7,11 @@
     -fx-padding: 24px;
 }
 
+.app-scroll {
+    -fx-background-color: transparent;
+    -fx-padding: 0;
+}
+
 .app-root.theme-light {
     -fx-background-color: linear-gradient(to bottom right, #f7f8ff, #e3eeff);
 }
@@ -36,16 +41,49 @@
     -fx-text-fill: rgba(26, 42, 108, 0.7);
 }
 
-.display-card {
+.display-card,
+.content-card {
     -fx-background-color: rgba(255, 255, 255, 0.08);
     -fx-background-radius: 20;
     -fx-border-color: rgba(255, 255, 255, 0.25);
     -fx-border-radius: 20;
 }
 
-.theme-light .display-card {
+.theme-light .display-card,
+.theme-light .content-card {
     -fx-background-color: rgba(255, 255, 255, 0.9);
     -fx-border-color: rgba(26, 42, 108, 0.2);
+}
+
+.card-title {
+    -fx-text-fill: white;
+    -fx-font-size: 20px;
+    -fx-font-weight: 700;
+}
+
+.theme-light .card-title {
+    -fx-text-fill: #1a2a6c;
+}
+
+.card-subtitle {
+    -fx-text-fill: rgba(255, 255, 255, 0.7);
+    -fx-font-size: 13px;
+    -fx-line-spacing: 2px;
+}
+
+.theme-light .card-subtitle {
+    -fx-text-fill: rgba(26, 42, 108, 0.6);
+}
+
+.section-title {
+    -fx-text-fill: rgba(255, 255, 255, 0.75);
+    -fx-font-size: 12px;
+    -fx-font-weight: 600;
+    -fx-letter-spacing: 0.3em;
+}
+
+.theme-light .section-title {
+    -fx-text-fill: rgba(26, 42, 108, 0.65);
 }
 
 .time-display {
@@ -202,4 +240,70 @@
 
 .theme-light .halo-circle {
     -fx-fill: radial-gradient(center 50% 50%, radius 75%, rgba(90,120,255,0.35), rgba(255,255,255,0));
+}
+
+.roadmap-item {
+    -fx-background-color: rgba(255, 255, 255, 0.06);
+    -fx-background-radius: 16;
+    -fx-padding: 14 18 14 18;
+}
+
+.theme-light .roadmap-item {
+    -fx-background-color: rgba(26, 42, 108, 0.08);
+}
+
+.roadmap-phase {
+    -fx-text-fill: white;
+    -fx-font-size: 15px;
+    -fx-font-weight: 600;
+}
+
+.theme-light .roadmap-phase {
+    -fx-text-fill: #1a2a6c;
+}
+
+.roadmap-focus {
+    -fx-text-fill: rgba(255, 255, 255, 0.75);
+    -fx-font-size: 13px;
+}
+
+.theme-light .roadmap-focus {
+    -fx-text-fill: rgba(26, 42, 108, 0.7);
+}
+
+.roadmap-status {
+    -fx-background-radius: 999;
+    -fx-padding: 4 14 4 14;
+    -fx-font-size: 12px;
+    -fx-font-weight: 700;
+    -fx-text-fill: white;
+    -fx-translate-y: 4px;
+}
+
+.status-active {
+    -fx-background-color: rgba(76, 175, 80, 0.55);
+}
+
+.status-planned {
+    -fx-background-color: rgba(255, 193, 7, 0.55);
+}
+
+.status-future {
+    -fx-background-color: rgba(59, 130, 246, 0.55);
+}
+
+.theme-light .roadmap-status {
+    -fx-text-fill: #1a2a6c;
+}
+
+.theme-light .status-active {
+    -fx-background-color: rgba(76, 175, 80, 0.18);
+}
+
+.theme-light .status-planned {
+    -fx-background-color: rgba(255, 193, 7, 0.22);
+}
+
+.theme-light .status-future {
+    -fx-background-color: rgba(59, 130, 246, 0.2);
 }


### PR DESCRIPTION
## 摘要
- 在 ScrollPane 中构建卡片网格，并监听内容宽度在 1 至 3 列间切换，适配不同屏幕
- 将计时显示、输入控制与 Roadmap 信息拆分成独立卡片，统一响应式风格
- 扩展主题样式，新增卡片标题及 Roadmap 状态标签等视觉元素

## 测试
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dac45b725c83288a9cfd3eb7a97c9f